### PR TITLE
Add "pypy" to tox.ini and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "pypy"
   - "3.2"
 env:
   - PYTHONPATH='.'
@@ -11,9 +12,7 @@ branches:
 before_install:
   - npm update
   - npm cache clean
-  - ~/virtualenv/python2.7/bin/activate
-  - npm install zombie
-  - ~/virtualenv/$TRAVIS_PYTHON_VERSION/bin/activate
+  - PYTHON=~/virtualenv/python2.7/bin/python npm install zombie
 install: 
   - pip install . --use-mirrors
   - pip install nose


### PR DESCRIPTION
Tox passes.

```
[last: 0] marca@scml-marca:~/dev/git-repos/python-zombie$ PAGER=cat git log -n 1
commit fdadaa0d2ab96a1f42f93d3634c7410212c2560c
Author: Marc Abramowitz <marc@marc-abramowitz.com>
Date:   Tue Jun 5 21:47:50 2012 -0700

    Add "pypy" to tox.ini and .travis.yml
[last: 0] marca@scml-marca:~/dev/git-repos/python-zombie$ tox
...
- tox test summary 
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  py32: commands succeeded
  pep8: commands succeeded
  congratulations :)
```

Travis keeps timing out because of all the apt-get stuff.
