### PR TITLE
return a stack trace in case of js error

### DIFF
--- a/zombie/proxy/client.py
+++ b/zombie/proxy/client.py
@@ -101,12 +101,12 @@ class ZombieProxyClient(object):
         try {
             browser.%s(%sfunction(err, browser){
                 if (err)
-                    stream.end(JSON.stringify(err.message));
+                    stream.end(JSON.stringify(err.stack));
                 else
                     stream.end();
             });
         } catch (err) {
-            stream.end(JSON.stringify(err.message));
+            stream.end(JSON.stringify(err.stack));
         }
         """ % (
             method,

--- a/zombie/tests/test_browser.py
+++ b/zombie/tests/test_browser.py
@@ -37,7 +37,7 @@ class TestServerCommunication(BrowserClientTest):
         try {
             browser.visit("%s", function(err, browser){
                 if (err)
-                    stream.end(JSON.stringify(err.message));
+                    stream.end(JSON.stringify(err.stack));
                 else
                     stream.end();
             });

--- a/zombie/tests/test_client.py
+++ b/zombie/tests/test_client.py
@@ -66,7 +66,7 @@ class TestServerCommunication(TestCase):
         try {
             browser.visit("%s", function(err, browser){
                 if (err)
-                    stream.end(JSON.stringify(err.message));
+                    stream.end(JSON.stringify(err.stack));
                 else
                     stream.end();
             });
@@ -91,7 +91,7 @@ class TestServerCommunication(TestCase):
         try {
             browser.wait(function(err, browser){
                 if (err)
-                    stream.end(JSON.stringify(err.message));
+                    stream.end(JSON.stringify(err.stack));
                 else
                     stream.end();
             });


### PR DESCRIPTION
Returning error.stack instead of only error.message is a big help in debugging why something fails. This includes error.message at the end of the js stack trace.

I didn't specifically write a test for how this generates a stack trace (as I didn't see a test for the previous behavior).

Hope I have the pull request right this time... no idea why it has all those other patches on it.
