### PR TITLE
docs: Fix a few typos

### DIFF
--- a/zombie/proxy/client.py
+++ b/zombie/proxy/client.py
@@ -108,7 +108,7 @@ class ZombieServerConnection(object):
 class ZombieProxyClient(object):
     """
     Sends data to a :class:`zombie.proxy.server.ZombieProxyServer` bound to
-    a specific TCP socket.  Data is evaulated by the server and results
+    a specific TCP socket.  Data is evaluated by the server and results
     (if any) are returned.
     """
 

--- a/zombie/tests/test_webserver.py
+++ b/zombie/tests/test_webserver.py
@@ -11,7 +11,7 @@ from zombie.tests.webserver import WebServerTestCase
 
 class TestServerTests(WebServerTestCase):
     """
-    Test the TestServer to make sure it does what we want and avoid misterious
+    Test the TestServer to make sure it does what we want and avoid mysterious
     problems during normal testing
     """
     def test_index(self):


### PR DESCRIPTION
There are small typos in:
- zombie/proxy/client.py
- zombie/tests/test_webserver.py

Fixes:
- Should read `mysterious` rather than `misterious`.
- Should read `evaluated` rather than `evaulated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md